### PR TITLE
Remove reminders about unofficial version and change category

### DIFF
--- a/snap/gui/liko-12.desktop
+++ b/snap/gui/liko-12.desktop
@@ -1,12 +1,7 @@
-# Demonstration desktop entry file for Snapcrafters Template Plus
-# Refer the Desktop Entry Specification on how to write this file:
-# https://specifications.freedesktop.org/desktop-entry-spec
 [Desktop Entry]
-Version=1.0
 Type=Application
-Name=LIKO-12 (snap)
+Name=LIKO-12
 Comment=An open-source fantasy computer, powered by LÖVE
 Exec=liko-12
 Icon=${SNAP}/meta/gui/icon.png
-Categories=Development
-
+Categories=Game

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: liko-12
-title: LIKO-12 (UNOFFICIAL)
+title: LIKO-12
 summary: An open-source fantasy computer, powered by LÖVE
 description: |
   LIKO-12 is a fantasy computer that you can use to make, play and share tiny retro-looking games and programs. It comes with a default, fully customizable, DOS-like operating system installed, called DiskOS.
@@ -7,11 +7,6 @@ description: |
   DiskOS provides an environment with basic command line programs and visual game editors.
 
   The created games and programs are saved as disk files that can be easily shared to friends or anyone else.
-
-  **Snap-specific information**
-
-  This is not an official distribution of LIKO-12, refer the snap's issue tracker for support: https://github.com/Lin-Buo-Ren/LIKO-12-snap/issues
-
 icon: snap/gui/icon.png
 license: MIT
 


### PR DESCRIPTION
Creator of LIKO-12 agreed to officialy support Snap packaging. I removed the inscription "(UNOFFICIAL)" from title and the warning from description about unofficial version.

Moreover, I changed category of .desktop file from "Development" to "Game" (it is more suitable).

By the way, you should change website in Snap Store to https://liko-12.github.io